### PR TITLE
Solve caching issue when performing blue-green deployment

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,8 @@ require 'action_mailer/railtie'
 require 'action_view/railtie'
 require 'action_cable/engine'
 
+require_relative '../lib/middlewares/cache_control'
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,7 +26,22 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  if ENV['RAILS_SERVE_STATIC_FILES'].to_b
+    config.public_file_server.enabled = true
+    config.public_file_server.headers = {
+      'Cache-Control' => 'public, max-age=2592000'
+    }
+
+    config.middleware.insert_before(
+      ActionDispatch::Static,
+      Middlewares::CacheControl,
+      paths['public'].first,
+      index:   config.public_file_server.index_name,
+      headers: config.public_file_server.headers
+    )
+  else
+    config.public_file_server.enabled = false
+  end
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass

--- a/lib/middlewares/cache_control.rb
+++ b/lib/middlewares/cache_control.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Middlewares
+  class CacheControl < ActionDispatch::Static
+    def call(env)
+      status, headers, response = super
+
+      headers['Cache-Control'] = 'private, max-age=0, must-revalidate' if status.in?(400..499)
+
+      [status, headers, response]
+    end
+  end
+end


### PR DESCRIPTION
Cloudflare was caching 404 requests by default for 3 minutes, leading to the site not working during and immediately after deployment. Explicitly setting cache for 404 assets should solve the issue.