### PR TITLE
Allow import preview to find a matched transaction by their import preview ID and default to a match in the UI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,3 +123,6 @@ RSpec/NestedGroups:
 
 RSpec/ContextWording:
   Enabled: false
+
+RSpec/IndexedLet:
+  Enabled: false

--- a/app/javascript/components/imports/ImportActionsSelect.vue
+++ b/app/javascript/components/imports/ImportActionsSelect.vue
@@ -16,6 +16,8 @@
 </template>
 
 <script>
+import _ from 'lodash';
+
 import { IMPORT_ACTIONS } from '~/utils/Constants.js';
 import I18n from '~/utils/I18n.js';
 
@@ -25,11 +27,16 @@ export default {
       type: String,
       default: null,
     },
+    allowMatch: {
+      type: Boolean,
+      required: true,
+    },
   },
 
   emits: ['update:modelValue', 'change'],
 
-  setup(_props, { emit }) {
+  setup(props, { emit }) {
+    const allowedActions = _.reject(IMPORT_ACTIONS, action => action.id === 'match' && !props.allowMatch);
     const handleChange = (ev) => {
       emit('update:modelValue', ev.target.value);
       emit('change', ev.target.value);
@@ -37,7 +44,7 @@ export default {
 
     return {
       t: I18n.scopedTranslator(''),
-      actions: IMPORT_ACTIONS,
+      actions: allowedActions,
       handleChange,
     };
   },

--- a/app/javascript/utils/Constants.js
+++ b/app/javascript/utils/Constants.js
@@ -87,8 +87,11 @@ export const GITHUB_REPO_URL = 'https://github.com/roooodcastro/finance-microman
 /*
  * Imports
  */
+export const IMPORT_ACTION_IMPORT = 'import';
+export const IMPORT_ACTION_SKIP = 'skip';
+export const IMPORT_ACTION_MATCH = 'match';
 export const IMPORT_ACTIONS = [
-  { id: 'import', labelI18nKey: 'views.imports.action_labels.import' },
-  { id: 'skip', labelI18nKey: 'views.imports.action_labels.skip' },
-  { id: 'match', labelI18nKey: 'views.imports.action_labels.match' },
+  { id: IMPORT_ACTION_IMPORT, labelI18nKey: 'views.imports.action_labels.import' },
+  { id: IMPORT_ACTION_SKIP, labelI18nKey: 'views.imports.action_labels.skip' },
+  { id: IMPORT_ACTION_MATCH, labelI18nKey: 'views.imports.action_labels.match' },
 ];

--- a/app/services/importer/ptsb.rb
+++ b/app/services/importer/ptsb.rb
@@ -9,13 +9,14 @@ module Importer
 
     def parse
       rows = read_file.then(&method(:filter_non_transaction_rows))
-      rows.map do |row|
-        raw_name = row[2]
-        name     = row[2].scan(TRANSACTION_NAME_REGEX).join(' ')
-        date     = extract_date(row)
-        amount   = row[3].to_f - row[4].to_f
+      rows.each_with_index.map do |row, index|
+        import_name      = row[2]
+        transaction_name = row[2].scan(TRANSACTION_NAME_REGEX).join(' ')
+        transaction_date = extract_date(row)
+        amount           = row[3].to_f - row[4].to_f
+        id               = calculate_transaction_id([index, import_name, transaction_name, transaction_date, amount])
 
-        [raw_name, name, date, amount]
+        { id:, import_name:, transaction_name:, transaction_date:, amount: }
       end
     end
 

--- a/db/migrate/20240626205017_add_transaction_import_id_to_transactions.rb
+++ b/db/migrate/20240626205017_add_transaction_import_id_to_transactions.rb
@@ -1,0 +1,7 @@
+class AddTransactionImportIdToTransactions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :transactions, :import_preview_id, :uuid, null: true
+
+    add_index :transactions, :import_preview_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,8 @@
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
-ActiveRecord::Schema[7.1].define(version: 2024_02_29_012155) do
+
+ActiveRecord::Schema[7.1].define(version: 2024_06_26_205017) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -119,7 +120,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_29_012155) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "balance_correction_transaction_id"
-    t.index ["balance_correction_transaction_id"], name: "index_reconciliations_on_balance_correction_transaction_id"
     t.index ["date"], name: "index_reconciliations_on_date"
     t.index ["profile_id"], name: "index_reconciliations_on_profile_id"
   end
@@ -194,10 +194,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_29_012155) do
     t.uuid "wallet_id"
     t.uuid "transaction_automation_id"
     t.uuid "import_id"
+    t.uuid "import_preview_id"
     t.index ["amount_cents"], name: "index_transactions_on_amount_cents"
     t.index ["category_id"], name: "index_transactions_on_category_id"
     t.index ["created_by_id"], name: "index_transactions_on_created_by_id"
     t.index ["import_id"], name: "index_transactions_on_import_id"
+    t.index ["import_preview_id"], name: "index_transactions_on_import_preview_id"
     t.index ["name"], name: "index_transactions_on_name"
     t.index ["profile_id"], name: "index_transactions_on_profile_id"
     t.index ["subcategory_id"], name: "index_transactions_on_subcategory_id"
@@ -264,7 +266,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_29_012155) do
   add_foreign_key "profiles", "users"
   add_foreign_key "profiles", "wallets", column: "default_wallet_id"
   add_foreign_key "reconciliations", "profiles"
-  add_foreign_key "reconciliations", "transactions", column: "balance_correction_transaction_id"
   add_foreign_key "reconciliations_wallets", "reconciliations"
   add_foreign_key "reconciliations_wallets", "wallets"
   add_foreign_key "subcategories", "categories"

--- a/spec/services/importer/base_spec.rb
+++ b/spec/services/importer/base_spec.rb
@@ -43,32 +43,39 @@ RSpec.describe Importer::Base, type: :service do
   describe '.generate_preview', :travel_to_now do
     subject { importer.generate_preview }
 
+    let(:id1) { SecureRandom.uuid }
+    let(:id2) { SecureRandom.uuid }
+
     let(:parsed_transactions) do
       [
-        ['Raw 1', 'Test 1', '2024-06-26', -4.99],
-        ['Raw 2', 'Test 2', '2024-06-28', 2]
+        { id: id1, import_name: 'Raw 1', transaction_name: 'Test 1', transaction_date: '2024-06-26', amount: -4.99 },
+        { id: id2, import_name: 'Raw 2', transaction_name: 'Test 2', transaction_date: '2024-06-28', amount: 2 }
       ]
     end
+
+    let!(:matched_transaction) { create(:transaction, import_preview_id: id2) }
 
     let(:expected_preview_data) do
       [
         {
-          id:               '0fb00c36-cfde-5024-bd0f-d0cb4ac8c0f6',
+          id:               id1,
           raw_import_name:  'Raw 1',
           name:             'Test 1',
           transaction_date: '2024-06-26',
           amount:           -4.99,
           wallet_id:        wallet.id,
-          action_id:        :import
+          action_id:        :import,
+          matches:          []
         },
         {
-          id:               '891eb336-2935-5cdd-9f22-b5421f9c4446',
+          id:               id2,
           raw_import_name:  'Raw 2',
           name:             'Test 2',
           transaction_date: '2024-06-28',
           amount:           2,
           wallet_id:        wallet.id,
-          action_id:        :import
+          action_id:        :match,
+          matches:          [matched_transaction.as_json]
         }
       ]
     end

--- a/spec/services/importer/ptsb_spec.rb
+++ b/spec/services/importer/ptsb_spec.rb
@@ -13,12 +13,48 @@ RSpec.describe Importer::PTSB, type: :service do
 
     let(:expected_transactions) do
       [
-        ['CNC TESCO STORES 03/05 1', 'CNC TESCO STORES', Date.parse('2023-05-03'), -15.25],
-        ['CNC MCDONALDS 70 02/05 1', 'CNC MCDONALDS', Date.parse('2023-05-02'), -8.95],
-        ['CNC TESCO STORES 02/05 2', 'CNC TESCO STORES', Date.parse('2023-05-02'), -2.0],
-        ['DD TEST DEBIT', 'DD TEST DEBIT', Date.parse('2023-05-03'), -12.34],
-        ['Apr Cash Earned', 'Apr Cash Earned', Date.parse('2023-05-02'), 5.00],
-        ['PTSB VISA         123456', 'PTSB VISA', Date.parse('2023-04-24'), -2.0]
+        {
+          id:               'ac194796-dc5a-558b-9945-10301efb798c',
+          import_name:      'CNC TESCO STORES 03/05 1',
+          transaction_name: 'CNC TESCO STORES',
+          transaction_date: Date.parse('2023-05-03'),
+          amount:           -15.25
+        },
+        {
+          id:               '4361b712-7cdc-594f-bf06-e8e079b4df35',
+          import_name:      'CNC MCDONALDS 70 02/05 1',
+          transaction_name: 'CNC MCDONALDS',
+          transaction_date: Date.parse('2023-05-02'),
+          amount:           -8.95
+        },
+        {
+          id:               '11649b54-c3e8-5192-a749-2d5a78829e66',
+          import_name:      'CNC TESCO STORES 02/05 2',
+          transaction_name: 'CNC TESCO STORES',
+          transaction_date: Date.parse('2023-05-02'),
+          amount:           -2.0
+        },
+        {
+          id:               '07efaa54-ea21-52db-9923-17673b85899a',
+          import_name:      'DD TEST DEBIT',
+          transaction_name: 'DD TEST DEBIT',
+          transaction_date: Date.parse('2023-05-03'),
+          amount:           -12.34
+        },
+        {
+          id:               '9ee8104a-168e-5ee8-8b83-6d22cd4a9e71',
+          import_name:      'Apr Cash Earned',
+          transaction_name: 'Apr Cash Earned',
+          transaction_date: Date.parse('2023-05-02'),
+          amount:           5.00
+        },
+        {
+          id:               '34ec48f8-a024-516a-be1c-bce788593242',
+          import_name:      'PTSB VISA         123456',
+          transaction_name: 'PTSB VISA',
+          transaction_date: Date.parse('2023-04-24'),
+          amount:           -2.0
+        }
       ]
     end
 


### PR DESCRIPTION
So that importing transactions that have already been imported will be automatically handled and not duplicated